### PR TITLE
Flexibility for imported brownfield infrastructure

### DIFF
--- a/locals.subnet.tf
+++ b/locals.subnet.tf
@@ -52,6 +52,7 @@ locals {
         virtual_network_key                           = k
         virtual_network_id                            = local.virtual_network_id[k]
         name                                          = subnet.name
+        address_prefix                                = subnet.address_prefix
         address_prefixes                              = subnet.address_prefixes
         nat_gateway                                   = subnet.nat_gateway
         network_security_group                        = subnet.network_security_group

--- a/main.routing.tf
+++ b/main.routing.tf
@@ -41,7 +41,7 @@ module "hub_routing_user_subnets" {
   location                      = each.value.location
   name                          = coalesce(var.hub_virtual_networks[each.key].route_table_name_user_subnets, "rt-user-subnets-${each.key}")
   resource_group_name           = try(each.value.resource_group_name, azurerm_resource_group.rg[each.key].name)
-  bgp_route_propagation_enabled = try(each.value.route_table_settings.bgp_route_propagation_enabled,true)
+  bgp_route_propagation_enabled = try(each.value.route_table_settings.bgp_route_propagation_enabled, true)
   enable_telemetry              = var.enable_telemetry
   tags                          = each.value.route_table_settings.tags == null ? (each.value.tags == null ? var.tags : each.value.tags) : each.value.route_table_settings.tags
 }

--- a/main.routing.tf
+++ b/main.routing.tf
@@ -41,9 +41,9 @@ module "hub_routing_user_subnets" {
   location                      = each.value.location
   name                          = coalesce(var.hub_virtual_networks[each.key].route_table_name_user_subnets, "rt-user-subnets-${each.key}")
   resource_group_name           = try(each.value.resource_group_name, azurerm_resource_group.rg[each.key].name)
-  bgp_route_propagation_enabled = true
+  bgp_route_propagation_enabled = try(each.value.route_table_settings.bgp_route_propagation_enabled,true)
   enable_telemetry              = var.enable_telemetry
-  tags                          = each.value.tags == null ? var.tags : each.value.tags
+  tags                          = each.value.route_table_settings.tags == null ? (each.value.tags == null ? var.tags : each.value.tags) : each.value.route_table_settings.tags
 }
 
 resource "azurerm_route" "user_subnets" {

--- a/main.virtual.network.tf
+++ b/main.virtual.network.tf
@@ -24,6 +24,7 @@ module "hub_virtual_network_subnets" {
   version  = "0.7.1"
   for_each = local.subnets
 
+  address_prefix                                = each.value.address_prefix
   address_prefixes                              = each.value.address_prefixes
   default_outbound_access_enabled               = each.value.default_outbound_access_enabled
   delegation                                    = each.value.delegation

--- a/main.virtual.network.tf
+++ b/main.virtual.network.tf
@@ -1,5 +1,5 @@
 module "hub_virtual_networks" {
-  source = "../avm-res-network-virtualnetwork"
+  source = "github.com/NetAion/avm-res-network-virtualnetwork?ref=v0.8.1-fork.1"
   # source   = "Azure/avm-res-network-virtualnetwork/azurerm"
   # version  = "0.7.1"
   for_each = var.hub_virtual_networks
@@ -22,7 +22,7 @@ module "hub_virtual_networks" {
 }
 
 module "hub_virtual_network_subnets" {
-  source = "../avm-res-network-virtualnetwork/modules/subnet"
+  source = "github.com/NetAion/avm-res-network-virtualnetwork//modules/subnet?ref=v0.8.1-fork.1"
   # source   = "Azure/avm-res-network-virtualnetwork/azurerm//modules/subnet"
   # version  = "0.7.1"
   for_each = local.subnets

--- a/main.virtual.network.tf
+++ b/main.virtual.network.tf
@@ -20,8 +20,9 @@ module "hub_virtual_networks" {
 }
 
 module "hub_virtual_network_subnets" {
-  source   = "Azure/avm-res-network-virtualnetwork/azurerm//modules/subnet"
-  version  = "0.7.1"
+  source = "../avm-res-network-virtualnetwork/modules/subnet"
+  # source   = "Azure/avm-res-network-virtualnetwork/azurerm//modules/subnet"
+  # version  = "0.7.1"
   for_each = local.subnets
 
   address_prefix                                = each.value.address_prefix

--- a/main.virtual.network.tf
+++ b/main.virtual.network.tf
@@ -1,6 +1,7 @@
 module "hub_virtual_networks" {
-  source   = "Azure/avm-res-network-virtualnetwork/azurerm"
-  version  = "0.7.1"
+  source = "../avm-res-network-virtualnetwork"
+  # source   = "Azure/avm-res-network-virtualnetwork/azurerm"
+  # version  = "0.7.1"
   for_each = var.hub_virtual_networks
 
   address_space       = each.value.address_space
@@ -13,10 +14,11 @@ module "hub_virtual_networks" {
   dns_servers = each.value.dns_servers == null ? null : {
     dns_servers = each.value.dns_servers
   }
-  enable_telemetry        = var.enable_telemetry
-  flow_timeout_in_minutes = each.value.flow_timeout_in_minutes
-  name                    = each.value.name
-  tags                    = each.value.tags == null ? var.tags : each.value.tags
+  enable_telemetry               = var.enable_telemetry
+  flow_timeout_in_minutes        = each.value.flow_timeout_in_minutes
+  private_endpoint_vnet_policies = each.value.private_endpoint_vnet_policies
+  name                           = each.value.name
+  tags                           = each.value.tags == null ? var.tags : each.value.tags
 }
 
 module "hub_virtual_network_subnets" {

--- a/variables.tf
+++ b/variables.tf
@@ -52,7 +52,8 @@ variable "hub_virtual_networks" {
     subnets = optional(map(object(
       {
         name             = string
-        address_prefixes = list(string)
+        address_prefix   = optional(string)
+        address_prefixes = optional(list(string))
         nat_gateway = optional(object({
           id = string
         }))

--- a/variables.tf
+++ b/variables.tf
@@ -85,7 +85,7 @@ variable "hub_virtual_networks" {
             }
           )
         ))
-        default_outbound_access_enabled = optional(bool, false)
+        default_outbound_access_enabled = optional(bool)
       }
     )), {})
 

--- a/variables.tf
+++ b/variables.tf
@@ -15,8 +15,14 @@ variable "hub_virtual_networks" {
     address_space                   = list(string)
     location                        = string
     resource_group_name             = string
+
     route_table_name_firewall       = optional(string)
     route_table_name_user_subnets   = optional(string)
+    route_table_settings = optional(object({
+      bgp_route_propagation_enabled = optional(bool,true)
+      tags                          = optional(map(string))
+    }))
+
     bgp_community                   = optional(string)
     ddos_protection_plan_id         = optional(string)
     dns_servers                     = optional(list(string))

--- a/variables.tf
+++ b/variables.tf
@@ -11,22 +11,21 @@ DESCRIPTION
 
 variable "hub_virtual_networks" {
   type = map(object({
-    name                            = string
-    address_space                   = list(string)
-    location                        = string
-    resource_group_name             = string
-
-    route_table_name_firewall       = optional(string)
-    route_table_name_user_subnets   = optional(string)
+    name                          = string
+    address_space                 = list(string)
+    location                      = string
+    resource_group_name           = string
+    route_table_name_firewall     = optional(string)
+    route_table_name_user_subnets = optional(string)
     route_table_settings = optional(object({
-      bgp_route_propagation_enabled = optional(bool,true)
+      bgp_route_propagation_enabled = optional(bool, true)
       tags                          = optional(map(string))
     }))
 
     bgp_community                   = optional(string)
     ddos_protection_plan_id         = optional(string)
     dns_servers                     = optional(list(string))
-    flow_timeout_in_minutes         = optional(number, 4)
+    flow_timeout_in_minutes         = optional(number)
     mesh_peering_enabled            = optional(bool, true)
     peering_names                   = optional(map(string))
     resource_group_creation_enabled = optional(bool, true)
@@ -36,6 +35,7 @@ variable "hub_virtual_networks" {
     routing_address_space           = optional(list(string), [])
     hub_router_ip_address           = optional(string)
     tags                            = optional(map(string))
+    private_endpoint_vnet_policies  = optional(string)
 
     route_table_entries_firewall = optional(set(object({
       name           = string


### PR DESCRIPTION
## Description
* feat: Ability to specify:
  * Subnet address_prefix
  * VNet private_endpoint_vnet_policies
  * Route table bgp_route_propagation_enabled
  * Route table tags
  * flow_timeout_in_minutes as unset (null), instead of default 4 minutes
  * default_outbound_access_enabled as unset (null), instead of default 'false'
* feat: source forked avm-res-network-virtualnetwork module from versioned repo